### PR TITLE
Improve type stability

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ThinPlateSplines"
 uuid = "1d861738-f48e-4029-b1d3-81ce6bc7f5ab"
 authors = ["Al Nejati"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ThinPlateSplines.jl
+++ b/src/ThinPlateSplines.jl
@@ -94,7 +94,7 @@ Thin-plate spline bending energy at the minimum.
 tps_energy(tps::ThinPlateSpline) = tps.λ*tr(tps.c*tps.Y')
 
 """
-	tps_deform(x2::AbstractArray, tps::ThinPlateSpline) 
+	tps_deform(x2::AbstractMatrix, tps::ThinPlateSpline) 
 
 calculate deformed locations of an input vector of positions`x2` according to thin-plate spline.
 Note that in combination with suitable interpolation packages can this be used to warp an image, but this function does not apply a warp by itself.
@@ -104,9 +104,10 @@ Yet it can be used to transform other mathematical structures rather than points
 	`x2`: coordinates of points to be deformed.
 	`tps`: the thin-plate spline structure of type `ThinPlateSpline` defining the deformation.
 """
-function tps_deform(x2::AbstractArray{T,D}, tps::ThinPlateSpline) where {T,D}
+function tps_deform(x2::AbstractMatrix{T}, tps::ThinPlateSpline) where {T}
     x1,d,c = tps.x1,tps.d,tps.c
 	d==[] && throw(ArgumentError("Affine component not available; run tps_solve with compute_affine=true."))
+	D = size(x2, 2)
     all_homo_z = cat(dims=2, ones(T, size(x2,1)), x2)
     # calculate sum of squares. Note that the summation is done outside the abs2
 	# it may be useful to join the terms below, but this seems a little harder than first thought

--- a/src/ThinPlateSplines.jl
+++ b/src/ThinPlateSplines.jl
@@ -7,26 +7,26 @@ export ThinPlateSpline
 export tps_solve, tps_energy, tps_deform
 
 """
-	ThinPlateSpline
+	ThinPlateSpline{Λ,X,T}
 
 the type (structure) holding the deformation information. This is needed to apply the deformation to other points using `tps_deform`.
 (see http://en.wikipedia.org/wiki/Thin_plate_spline for more information)
 	
 # Members
-`λ`  # Stiffness.
-`x1` # control points
-`Y`  # Homogeneous control point coordinates
-`Φ`  # TPS kernel
-`d`  # Affine component
-`c`  # Non-affine component
+`λ::Λ`          # Stiffness.
+`x1::X`         # control points
+`Y::Matrix{T}`  # Homogeneous control point coordinates
+`Φ::Matrix{T}`  # TPS kernel
+`d::Matrix{T}`  # Affine component
+`c::Matrix{T}`  # Non-affine component
 """
-struct ThinPlateSpline
-	λ  # Stiffness.
-	x1 # control points
-	Y  # Homogeneous control point coordinates
-	Φ  # TPS kernel
-	d  # Affine component
-	c  # Non-affine component
+struct ThinPlateSpline{Λ,X,T}
+	λ::Λ          # Stiffness.
+	x1::Matrix{X} # control points
+	Y::Matrix{T}  # Homogeneous control point coordinates
+	Φ::Matrix{T}  # TPS kernel
+	d::Matrix{T}  # Affine component
+	c::Matrix{T}  # Non-affine component
 end
 
 # Thin-plate splines.
@@ -108,7 +108,7 @@ function tps_deform(x2::AbstractMatrix{T}, tps::ThinPlateSpline) where {T}
     x1,d,c = tps.x1,tps.d,tps.c
 	d==[] && throw(ArgumentError("Affine component not available; run tps_solve with compute_affine=true."))
 	D = size(x2, 2)
-    all_homo_z = cat(dims=2, ones(T, size(x2,1)), x2)
+    all_homo_z = hcat(ones(T, size(x2,1)), x2)
     # calculate sum of squares. Note that the summation is done outside the abs2
 	# it may be useful to join the terms below, but this seems a little harder than first thought
     @tullio sumsqr[k,j] := abs2(all_homo_z[k,m+1] .- x1[j,m])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,3 +44,25 @@ end
 @testset "tps_energy" begin
     @test tps_energy(tps) ≈ 0
 end
+
+@testset "Three dimensions" begin
+  start_pts = [0 0 0; 0 0 1; 0 1 0; 1 0 0]
+  end_pts = [-0.7 -0.7 0; 0 0 1; 0 1 0; 1 0 0]
+  tps = tps_solve(start_pts, end_pts, 1.0)
+  deformed = tps_deform(start_pts, tps)
+  @test size(deformed,1) == size(start_pts, 1)
+  @test size(deformed,2) == size(start_pts, 2)
+  @test deformed ≈ end_pts
+  @test tps_deform([0.5 0.5 0.5], tps) ≈ [0.85 0.85 0.5]
+end
+
+@testset "Four dimensions" begin
+  start_pts = [0 0 0 0; 0 0 0 1; 0 0 1 0; 0 1 0 0; 1 0 0 0]
+  end_pts = [-0.7 -0.7 0 0; 0 0 0 1; 0 0 1 0; 0 1 0 0; 1 0 0 0]
+  tps = tps_solve(start_pts, end_pts, 1.0)
+  deformed = tps_deform(start_pts, tps)
+  @test size(deformed,1) == size(start_pts, 1)
+  @test size(deformed,2) == size(start_pts, 2)
+  @test deformed ≈ end_pts
+  @test tps_deform([0.5 0.5 0.5 0.5], tps) ≈ [1.2 1.2 0.5 0.5]
+end


### PR DESCRIPTION
* Parameterize `ThinPlateSpline`
* Use `hcat` rather than `cat(dims = 2, ...)`